### PR TITLE
Fix/reload window at session end

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -378,7 +378,7 @@ export class SermasToolkit {
       if (settings?.interactionStart == 'on-load') {
         // on session close, generate new sessionId and propagate to APIs
         this.logger.log(`Creating new session id`);
-        this.createSessionId();
+        sessionStatus.sessionId = this.createSessionId();
       } else {
         this.setSessionId(undefined);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,15 +346,16 @@ export class SermasToolkit {
 
   async onSessionChanged(ev: SessionChangedDto) {
     if (!ev.record?.sessionId) return;
-
+    let status: 'created' | 'updated' | 'closed' = 'created';
+    if (ev.operation === 'updated') status = 'updated';
+    if (
+      (ev.operation === 'updated' && ev.record?.closedAt) ||
+      ev.operation === 'deleted'
+    )
+      status = 'closed';
     const sessionStatus: SessionStatusEvent = {
       sessionId: ev.record?.sessionId,
-      status:
-        ev.operation === 'updated' && ev.record?.closedAt
-          ? 'closed'
-          : ev.operation === 'updated'
-            ? 'updated'
-            : 'created',
+      status,
     };
 
     this.logger.debug(


### PR DESCRIPTION
The new sessionId is now carried by the event.
See also fix in kiosk